### PR TITLE
修复：缺失方案依赖配置。

### DIFF
--- a/方案/c_42.schema.yaml
+++ b/方案/c_42.schema.yaml
@@ -10,6 +10,10 @@ schema:
     - 蓝落萧改编
   description: |
     改编自 Cicin 所作的 C 输入，取前 3 码为全码，4 码顶 2 码上屏
+  dependencies:
+    - c_42a
+    - pinyin_simp
+    - stroke
  
 
 switches:


### PR DESCRIPTION
缺少三个依赖方案的定义，部署时不会编译这三个方案。曾经编译过这些方案的用家因为 build 目录中遗留了文件，不会遇到问题。